### PR TITLE
add evaluation

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,26 @@
+# Instructions to evaluate Doge
+
+We use the [lighteval](https://github.com/huggingface/lighteval) toolkit to evaluate the performance of the Doge model.
+
+## Setup
+
+You can install the toolkit using the following command:
+
+```bash
+pip install lighteval
+```
+
+## Evaluation
+
+If you are a Linux user, you can use the following command to evaluate the model:
+
+```bash
+bash ./evaluation/eval_downstream_tasks.sh
+```
+
+If you are a Windows user, you can use the following command to evaluate the model:
+
+```bash
+. ./evaluation/eval_downstream_tasks.ps1
+```
+> Note: You can modify `MODEL` and `OUTPUT_DIR` in the script to evaluate different models and save the results to different directories.

--- a/evaluation/eval_downstream_tasks.ps1
+++ b/evaluation/eval_downstream_tasks.ps1
@@ -1,0 +1,16 @@
+
+$MODEL = "JingzeShi/Doge-20M"
+$OUTPUT_DIR = "./lighteval_results"
+
+if ($MODEL -match "Instruct$") {
+    lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" `
+    "extended|ifeval|5|0" `
+    --override-batch-size 1 `
+    --output-dir $OUTPUT_DIR `
+    --use-chat-template
+} else {
+    lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" `
+    "original|mmlu|5|0,lighteval|triviaqa|5|0,lighteval|arc:easy|5|0,leaderboard|arc:challenge|5|0,lighteval|piqa|5|0,leaderboard|hellaswag|5|0,lighteval|openbookqa|5|0,leaderboard|winogrande|5|0" `
+    --override-batch-size 1 `
+    --output-dir $OUTPUT_DIR
+}

--- a/evaluation/eval_downstream_tasks.sh
+++ b/evaluation/eval_downstream_tasks.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+MODEL="JingzeShi/Doge-20M"
+OUTPUT_DIR="./lighteval_results"
+
+if [[ $MODEL =~ Instruct$ ]]; then
+    lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" \
+    "extended|ifeval|5|0" \
+    --override-batch-size 1 \
+    --output-dir $OUTPUT_DIR \
+    --use-chat-template
+else
+    lighteval accelerate "pretrained=$MODEL,max_length=2048,trust_remote_code=True" \
+    "original|mmlu|5|0,lighteval|triviaqa|5|0,lighteval|arc:easy|5|0,leaderboard|arc:challenge|5|0,lighteval|piqa|5|0,leaderboard|hellaswag|5|0,lighteval|openbookqa|5|0,leaderboard|winogrande|5|0" \
+    --override-batch-size 1 \
+    --output-dir $OUTPUT_DIR
+fi


### PR DESCRIPTION
This pull request introduces a new evaluation setup for the Doge model using the lighteval toolkit. It includes instructions for both Linux and Windows users and provides scripts to perform the evaluation.

Documentation updates:

* [`evaluation/README.md`](diffhunk://#diff-f805fea08479ad131f67bfc6e9ecc475af423fb18f8c4bb760c625c88a57c495R1-R26): Added detailed instructions on how to evaluate the Doge model using the lighteval toolkit, including setup and commands for both Linux and Windows users.

Evaluation scripts:

* [`evaluation/eval_downstream_tasks.sh`](diffhunk://#diff-bc5777a9b77db514f9baad35aa8f64b37b1d2cc267b8231c114fa39cabdd00eeR1-R17): Added a bash script to evaluate the Doge model on various tasks using the lighteval toolkit for Linux users.
* [`evaluation/eval_downstream_tasks.ps1`](diffhunk://#diff-c8f9721d2f9c8880ce391ffa2283af73444b73a0e652ee21aab3c6f0ebbc0fb9R1-R16): Added a PowerShell script to evaluate the Doge model on various tasks using the lighteval toolkit for Windows users.