### PR TITLE
Add pre-training recipes

### DIFF
--- a/recipes/doge/Doge-160M/config_full.yaml
+++ b/recipes/doge/Doge-160M/config_full.yaml
@@ -1,0 +1,72 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: "no"
+output_dir: data/Doge-160M
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-160M
+hub_strategy: every_save
+
+# Model arguments
+mmodel_config:
+  vocab_size: 32768
+  hidden_size: 768
+  intermediate_size: 1536
+  num_hidden_layers: 24
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 6
+  num_key_value_heads: 3
+
+model_name_or_path: SmallDoge/Doge-160M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pretrain_dataset
+dataset_configs:
+- all
+preprocessing_num_workers: 8
+
+# PT trainer arguments
+seed: 233
+do_train: True
+max_train_steps: 24000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 4.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 2400
+  min_lr_ratio: 0.0
+warmup_steps: 2400
+weight_decay: 0.01
+gradient_accumulation_steps: 768
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-20M/config_full.yaml
+++ b/recipes/doge/Doge-20M/config_full.yaml
@@ -1,0 +1,72 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: "no"
+output_dir: data/Doge-20M
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-20M
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 32768
+  hidden_size: 256
+  intermediate_size: 512
+  num_hidden_layers: 8
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 2
+  num_key_value_heads: 1
+
+model_name_or_path: SmallDoge/Doge-20M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pretrain_dataset
+dataset_configs:
+- all
+preprocessing_num_workers: 8
+
+# PT trainer arguments
+seed: 233
+do_train: True
+max_train_steps: 8000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 8.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 800
+  min_lr_ratio: 0.0
+warmup_steps: 800
+weight_decay: 0.01
+gradient_accumulation_steps: 256
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-320M/config_full.yaml
+++ b/recipes/doge/Doge-320M/config_full.yaml
@@ -1,0 +1,72 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: "no"
+output_dir: data/Doge-320M
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-320M
+hub_strategy: every_save
+
+# Model arguments
+mmodel_config:
+  vocab_size: 32768
+  hidden_size: 1024
+  intermediate_size: 2048
+  num_hidden_layers: 32
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 8
+  num_key_value_heads: 4
+
+model_name_or_path: SmallDoge/Doge-320M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pretrain_dataset
+dataset_configs:
+- all
+preprocessing_num_workers: 8
+
+# PT trainer arguments
+seed: 233
+do_train: True
+max_train_steps: 24000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 2.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 3200
+  min_lr_ratio: 0.0
+warmup_steps: 3200
+weight_decay: 0.01
+gradient_accumulation_steps: 1024
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True

--- a/recipes/doge/Doge-60M/config_full.yaml
+++ b/recipes/doge/Doge-60M/config_full.yaml
@@ -1,0 +1,72 @@
+# Logging and Output arguments
+log_level: info
+logging_strategy: steps
+logging_steps: 100
+report_to:
+- tensorboard
+- wandb
+save_strategy: "no"
+output_dir: data/Doge-60M
+overwrite_output_dir: true
+push_to_hub: true
+private: true
+# token: <your-token>
+hub_model_id: Doge-60M
+hub_strategy: every_save
+
+# Model arguments
+model_config:
+  vocab_size: 32768
+  hidden_size: 512
+  intermediate_size: 1024
+  num_hidden_layers: 16
+  hidden_dropout: 0.0
+  hidden_act: "silu"
+  use_cache: True
+  tie_word_embeddings: True
+  max_position_embeddings: 2048
+  rope_theta: 10000.0
+  rope_scaling:
+    rope_type: dynamic
+    factor: 4.0
+    original_max_position_embeddings: 2048
+  num_attention_heads: 4
+  num_key_value_heads: 2
+
+model_name_or_path: SmallDoge/Doge-60M
+torch_dtype: bfloat16
+
+# Data training arguments
+dataset_name: ./datasets/pretrain_dataset
+dataset_configs:
+- all
+preprocessing_num_workers: 8
+
+# PT trainer arguments
+seed: 233
+do_train: True
+max_train_steps: 16000
+per_device_train_batch_size: 1
+do_eval: True
+eval_strategy: steps
+eval_steps: 100
+per_device_eval_batch_size: 1
+optim: adamw_torch_fused
+adam_beta1: 0.9
+adam_beta2: 0.95
+adam_epsilon: 1.0e-8
+learning_rate: 6.0e-3
+lr_scheduler_type: warmup_stable_decay
+lr_scheduler_kwargs:
+  warmup_type: linear
+  decay_type: linear
+  num_decay_steps: 1600
+  min_lr_ratio: 0.0
+warmup_steps: 1600
+weight_decay: 0.01
+gradient_accumulation_steps: 512
+gradient_checkpointing: true
+gradient_checkpointing_kwargs:
+  use_reentrant: false
+max_grad_norm: 1.0
+bf16: True


### PR DESCRIPTION
This pull request introduces new configuration files for different models in the Doge series, each with its own set of logging, model, data training, and PT trainer arguments. The most important changes include the addition of configuration files for Doge-160M, Doge-20M, Doge-320M, and Doge-60M models.

Configuration files added:

* [`recipes/doge/Doge-160M/config_full.yaml`](diffhunk://#diff-4e4d4268d6f286f3a189b3848918078542a1323d0835cfbbdf4d3668a3873f1dR1-R72): Added configuration for Doge-160M model, including logging, model, data training, and PT trainer arguments.
* [`recipes/doge/Doge-20M/config_full.yaml`](diffhunk://#diff-58558c9d2b3c4594a9f4db645a077f53ecc16905a79507623206d71c9e87b412R1-R72): Added configuration for Doge-20M model, including logging, model, data training, and PT trainer arguments.
* [`recipes/doge/Doge-320M/config_full.yaml`](diffhunk://#diff-41f9421c80577c172a4ea52164d34efd47484836194ea950da760de49e7a1a30R1-R72): Added configuration for Doge-320M model, including logging, model, data training, and PT trainer arguments.
* [`recipes/doge/Doge-60M/config_full.yaml`](diffhunk://#diff-43fbfb376200c2c35bce1e915607ed31f1d64d767f34b23b8d310f811c3b4355R1-R72): Added configuration for Doge-60M model, including logging, model, data training, and PT trainer arguments.