### PR TITLE
Update model register for push model to hub

### DIFF
--- a/src/small_doge/pt.py
+++ b/src/small_doge/pt.py
@@ -188,7 +188,9 @@ def main(script_args, training_args, model_args, model_config):
     DogeModel.register_for_auto_class("AutoModel")
     DogeForCausalLM.register_for_auto_class("AutoModelForCausalLM")
     tokenizer = AutoTokenizer.from_pretrained(f'{training_args.output_dir}')
+    tokenizer.save_pretrained(f'{training_args.output_dir}')
     model = AutoModelForCausalLM.from_pretrained(f'{training_args.output_dir}')
+    model.save_pretrained(f'{training_args.output_dir}')
 
     if training_args.push_to_hub:
         logger.info("Pushing to hub...")

--- a/src/small_doge/sft.py
+++ b/src/small_doge/sft.py
@@ -181,7 +181,9 @@ def main(script_args, training_args, model_args):
     DogeModel.register_for_auto_class("AutoModel")
     DogeForCausalLM.register_for_auto_class("AutoModelForCausalLM")
     tokenizer = AutoTokenizer.from_pretrained(f'{training_args.output_dir}')
+    tokenizer.save_pretrained(f'{training_args.output_dir}')
     model = AutoModelForCausalLM.from_pretrained(f'{training_args.output_dir}')
+    model.save_pretrained(f'{training_args.output_dir}')
 
     if training_args.push_to_hub:
         logger.info("Pushing to hub...")


### PR DESCRIPTION
This pull request includes changes to the `src/small_doge/pt.py` and `src/small_doge/sft.py` files to ensure that the tokenizer and model are saved after being loaded from the specified directory.

Changes to `src/small_doge/pt.py` and `src/small_doge/sft.py`:

* Added `tokenizer.save_pretrained(f'{training_args.output_dir}')` to save the tokenizer after loading it from the specified directory. [[1]](diffhunk://#diff-960c9033062defa6afe110f7600dcd9cafa19f453ebf6b73fcb7b290c120d964R191-R193) [[2]](diffhunk://#diff-14bef8ecce5eb19ce8d9ad35ab60444590cd9e43a18935e246ccae1bb9e885e8R184-R186)
* Added `model.save_pretrained(f'{training_args.output_dir}')` to save the model after loading it from the specified directory. [[1]](diffhunk://#diff-960c9033062defa6afe110f7600dcd9cafa19f453ebf6b73fcb7b290c120d964R191-R193) [[2]](diffhunk://#diff-14bef8ecce5eb19ce8d9ad35ab60444590cd9e43a18935e246ccae1bb9e885e8R184-R186)