### PR TITLE
Add training instructions for doge recipes

### DIFF
--- a/examples/notebook.ipynb
+++ b/examples/notebook.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Download Pre-Training and Fine-Tuning Datasets\n",
+    "### Download Pre-Training Datasets\n",
     "\n",
     "\n",
     "For the pre-training dataset, we selected the high-quality text `fineweb-edu-dedup`, the synthetic instruction dataset `cosmopedia-v2`, and supplemented it with `python-edu` and `fine-math` to ensure the model's code and mathematical capabilities.\n",

--- a/examples/notebook_zh.ipynb
+++ b/examples/notebook_zh.ipynb
@@ -23,7 +23,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 下载预训练与微调数据集\n",
+    "### 下载预训练数据集\n",
     "\n",
     "\n",
     "预训练数据集, 我们选取了 `fineweb-edu-dedup` 高质量文本, `cosmopedia-v2` 合成指令数据集, 并补充 `python-edu` 与 `fine-math` 来保证模型的代码与数学能力. \n",

--- a/recipes/doge/README.md
+++ b/recipes/doge/README.md
@@ -1,0 +1,267 @@
+# Instructions to train Doge
+
+We provide detailed steps to train Doge in this guide, including pre-training Doge, instruction fine-tuning Doge-Instruct, and reasoning fine-tuning Doge-R1.
+
+
+## Installation
+
+Please follow the instructions in [README](../README.md) to install the necessary dependencies.
+
+
+## Pre-training
+
+We provide a Doge checkpoint that can be further pre-trained on a new dataset. If you need it, please refer to [here](https://huggingface.co/collections/SmallDoge/doge-checkpoint-679ce95dae1d498e3ad35068) for more information.
+
+### Download the dataset
+
+For the pre-training dataset, we selected the `fineweb-edu-dedup` high-quality text, `cosmopedia-v2` synthetic instruction dataset, and supplemented `python-edu` and `fine-math` to ensure the model's code and math capabilities.
+
+```shell
+# Fill in the save path, cache path, and number of processes
+python ./examples/utils/download_pt_datasets.py --save_dir ./datasets --cache_dir ./cache --num_proc 1
+```
+
+> [!NOTE]
+> Due to the large size of the dataset, at least 2TB of storage space is required. If you do not have enough storage space, you can choose to download part of the dataset by yourself [here](./utils/download_pt_datasets.py).
+> You can freely change the downloaded dataset. We provide this example just to reproduce the current open-source model.
+
+### Preprocess the dataset
+
+We need to use the `tokenizer` to convert the dataset into `input_ids` and `attention_mask` that the model can accept.
+If you use `LlamaTokenizer`, the tokenizer's vocabulary size is `32768`, and it uses `[INST]` and `[/INST]` to mark instructions. It also includes tool tokens, but we will not use them here.
+Datasets like cosmopedia-v2 include two fields, `prompt` and `text`, which we mark as user content and assistant content.
+
+```python
+conversation = [
+    {"role": "user", "content": prompt},
+    {"role": "assistant", "content": text},
+]
+return tokenizer.apply_chat_template(conversation, tokenize=True, padding='max_length', truncation=True, max_length=MAX_LENGTH, return_dict=True)
+```
+
+Of course, you can also add some instruction prompts by yourself, such as letting the model answer that it is Doge, not ChatGPT.
+
+```python
+conversation = [
+    {"role": "user", "content": "Who are you?"},
+    {"role": "assistant", "content": "I am an AI assistant named `Doge`. I am a language model trained by the `SmallDoge` community based on the `Doge` architecture. My task is to provide appropriate answers and support based on the user's questions and requests."},
+    {"role": "user", "content": prompt},
+    {"role": "assistant", "content": text},
+]
+```
+
+Here we recommend using [Doge-tokenizer](https://huggingface.co/SmallDoge/Doge-tokenizer) to process the dataset. It is trained by the `Llama-3.3` tokenizer on the `smollm-corpus`, with a vocabulary size of `32768`. The training script can be found [here](ttps://github.com/SamllDoge/small-doge/blob/main/examples/utils/train_tokenizer_from_old.py).
+
+```shell
+# Fill in the dataset path, save path, tokenizer path, sample number, maximum length, and number of processes
+python ./examples/utils/preprocess_pt_datasets.py --datasets_dir ./datasets --save_dir ./datasets --tokenizer_name_or_path SamllDoge/Doge-tokenizer --train_examples 128000000 --test_examples 1000 --max_length 2048 --num_proc 16
+```
+
+> [!NOTE]
+> We only keep the dataset with 256B tokens, and the ratio of fineweb-edu:cosmopedia-v2:python-edu:open-web-math = 7:2:0.5:0.5. If you need to train a larger model, please increase the scale of the dataset by yourself.
+
+### Concatenate the dataset
+
+We concatenate the fineweb-edu_tokenized, cosmopedia-v2, python-edu, and finemath datasets into the `pretrain` dataset.
+Then we shuffle them in order `seed=233`, and split out `1,000` samples as the test set.
+
+```shell
+# Fill in the dataset path, save path, sample number, and number of processes
+python ./examples/utils/concatenate_pt_datasets.py --datasets_dir ./datasets --save_dir ./datasets --train_examples 128000000 --test_examples 1000 --num_proc 16
+```
+
+### Configure the model parameters
+
+We configure a `20M` small model for training and testing.
+
+| Model | Params | n_layers | d_model | d_ff | n_heads | kv_heads | n_exprets | n_expert_heads | n_expert_pre_head |
+|---|---|---|---|---|---|---|---|---|---|
+| Doge-20M | 13M | 8 | 256 | 512 | 2 | 1 | - | - | - |
+| Doge-60M | 54M | 16 | 512 | 1024 | 4 | 2 | - | - | - |
+| Doge-160M | 152M | 24 | 768 | 1536 | 6 | 3 | - | - | - |
+| Doge-320M | 335M | 32 | 1024 | 2048 | 8 | 4 | - | - | - |
+
+- n_layers is the number of decoder layers in the model
+- d_model is the hidden layer dimension of the model
+- n_heads is the number of heads of multi-head attention, d_model // n_heads is best kept above 64
+
+> [!TIP]
+> The `Doge-MoE` model can inherit the dense activation parameters of the `Doge` model and increase the sparse activation parameters by setting `n_experts`, `n_expert_heads`, and `n_expert_pre_head`. If you want to increase the model parameters without increasing the computational cost, you can try setting the `is_moe` parameter of the model configuration to `True` and adjust the above parameters.
+
+### Configure the pre-training hyperparameters
+
+| Model | tokens | max_train_steps | accumulate_steps | learning_rate | scheduler | warmup_ratio | decay_ratio | weight_decay | min_lr_rate |
+|---|---|---|---|---|---|---|---|---|---|
+| Doge-20M | 4B | 8,000 | 256 | 8e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+| Doge-60M | 16B | 16,000 | 512 | 6e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+| Doge-160M | 32B | 24,000 | 768 | 4e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+| Doge-320M | 64B | 32,000 | 1024 | 2e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+
+> [!NOTE]
+> According to the experience of [SmolLM blog](https://huggingface.co/blog/smollm), we will scale the parameters in [Chinchilla](https://arxiv.org/pdf/2203.15556) by 10 times the scaling ratio of tokens.
+> `warmup_stable_decay` is used to continue training with checkpoints on larger datasets at any time, see [Scaling Laws and Compute-Optimal Training Beyond Fixed Training Durations](https://arxiv.org/pdf/2405.18392).
+
+### Pre-training the model
+
+We support training the model using Single GPU, DDP, or DeepSpeed ZeRO-2 and ZeRO-3. To switch between these four methods, simply change the path in the [`accelerate_configs`](../accelerate_configs) YAML configuration in the `recipes` directory.
+
+> [!NOTE]
+> We do not install `DeepSpeed` by default because Windows systems do not support it. If you need to use it, please install it yourself.
+
+```shell
+# You need to specify the configuration file path, all parameters are in the recipe configuration file
+ACCELERATE_LOG_LEVEL=info accelerate launch ./src/small_doge/pt.py --config_file recipes/accelerate_configs/single_gpu.yaml --config recipes/doge/Doge-20M/config_full.yaml
+```
+
+> [!NOTE]
+> The training command above is configured for a 1 x RTX 4090 (24GB) node. For different hardware and topologies, you may need to adjust the batch size and gradient accumulation steps.
+
+### Usage
+
+After training is complete, we can use `AutoModelForCausalLM` of `Transformers` to load the model, and use `AutoTokenizer` to load `LlamaTokenizer`.
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-20M")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-20M", trust_remote_code=True)
+
+inputs = tokenizer("Hey how are you doing?", return_tensors="pt")
+
+out = model.generate(**inputs, max_new_tokens=20)
+print(tokenizer.batch_decode(out))
+```
+
+### Evaluation
+
+We use the [lighteval](https://github.com/huggingface/lighteval) toolkit to evaluate the performance of the Doge model.
+
+You can install the toolkit with the following command:
+
+```bash
+pip install lighteval
+```
+
+> [!NOTE]
+> By default, lighteval installs `torch==2.4.1`, so you may need to create a new environment to install it.
+
+If you are a Linux user, you can use the following command to evaluate the model:
+
+```bash
+bash ./evaluation/eval_downstream_tasks.sh
+```
+
+If you are a Windows user, you can use the following command to evaluate the model:
+
+```powershell
+. ./evaluation/eval_downstream_tasks.ps1
+```
+
+> [!NOTE]
+> You can modify `MODEL` and `OUTPUT_DIR` in the script to evaluate different models and save the results to different directories.
+
+### Instruction Fine-tuning
+
+We provide a base Doge model that can be fine-tuned directly for instruction fine-tuning. If you need it, please refer to [here](https://huggingface.co/collections/SmallDoge/doge-slm-679cc991f027c4a3abbded4a) for more information.
+
+### Download the dataset
+
+For the fine-tuning dataset, we selected the `smoltalk` dataset for SFT and the `ultrafeedback_binarized` dataset for DPO.
+
+```shell
+# Fill in the save path, cache path, and number of processes
+python ./examples/utils/download_ft_dataset.py --save_dir ./datasets --cache_dir ./cache --num_proc 1
+```
+
+> [!NOTE]
+> You can freely change the downloaded dataset. We provide this example just to reproduce the current open-source model.
+
+### Preprocess the dataset
+
+We apply the fine-tuning dataset to the `chat template`.
+
+```python
+# Fill in the dataset path, save path, tokenizer path, and number of processes
+python ./examples/utils/preprocess_ft_datasets.py --datasets_dir ./datasets --save_dir ./datasets --tokenizer_name_or_path SmallDoge/Doge-tokenizer --num_proc 8
+```
+
+> [!NOTE]
+> You can add some instruction prompts in the template by yourself, such as letting the model answer that it is Doge, not ChatGPT.
+
+### Concatenate the dataset
+
+If you download more datasets for fine-tuning, we need to concatenate and shuffle them to mix them together.
+
+```shell
+# Fill in the dataset path, save path, sample number, and number of processes
+python ./examples/utils/concatenate_ft_datasets.py --datasets_dir ./datasets --save_dir ./datasets --num_proc 16
+```
+
+### SFT the model
+
+We first fine-tune the model to follow the `prompt` to generate a reply.
+
+```shell
+# You need to specify the configuration file path, all parameters are in the recipe configuration file
+ACCELERATE_LOG_LEVEL=info accelerate launch ./src/small_doge/sft.py --config_file recipes/accelerate_configs/single_gpu.yaml --config recipes/doge/Doge-20M-Instruct/sft/config_full.yaml
+```
+
+> [!NOTE]
+> The training command above is configured for a 1 x RTX 4090 (24GB) node. For different hardware and topologies, you may need to adjust the batch size and gradient accumulation steps.
+
+### DPO the model
+
+Then we use the DPO algorithm to align the model with human preferences after SFT.
+
+```shell
+# You need to specify the configuration file path, all parameters are in the recipe configuration file
+ACCELERATE_LOG_LEVEL=info accelerate launch ./src/small_doge/dpo.py --config_file recipes/accelerate_configs/single_gpu.yaml --config recipes/doge/Doge-20M-Instruct/dpo/config_full.yaml
+```
+
+> [!NOTE]
+> The training command above is configured for a 1 x RTX 4090 (24GB) node. For different hardware and topologies, you may need to adjust the batch size and gradient accumulation steps.
+
+## Usage
+
+After fine-tuning is complete, we can use `AutoModelForCausalLM` of `Transformers` to load the model, and use `AutoTokenizer` to load `LlamaTokenizer`, and use `GenerationConfig` and `TextStreamer` to support streaming generation with sampling.
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-20M-Instruct")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-20M-Instruct", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(tokenizer=tokenizer, skip_prompt=True)
+
+prompt = "Hi, how are you doing today?"
+
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+
+## Reasoning Fine-tuning
+
+> [!NOTE]
+> TODO

--- a/recipes/doge/README_zh.md
+++ b/recipes/doge/README_zh.md
@@ -1,0 +1,268 @@
+# Doge训练指南
+
+我们在本指南中提供了训练Doge的详细步骤, 包括预训练的Doge, 指令微调的Doge-Instruct, 以及将要更新的推理微调的Doge-R1.
+
+
+## 安装
+
+请按照[README](../README.md)中的说明安装必要的依赖项.
+
+
+## 预训练
+
+我们提供了可以在新数据集上继续预训练的Doge检查点, 如果您有需要的话, 请参阅[这里](https://huggingface.co/collections/SmallDoge/doge-checkpoint-679ce95dae1d498e3ad35068)以获取更多信息.
+
+### 下载数据集
+
+预训练数据集, 我们选取了 `fineweb-edu-dedup` 高质量文本, `cosmopedia-v2` 合成指令数据集, 并补充 `python-edu` 与 `fine-math` 来保证模型的代码与数学能力. 
+
+```shell
+# 填写保存路径, 缓存路径和进程数
+python ./examples/utils/download_pt_datasets.py --save_dir ./datasets --cache_dir ./cache --num_proc 1
+```
+
+> [!NOTE]
+> 由于数据集过大, 至少需要 2TB 的存储空间. 如果您的存储空间不足, 可以自行在[这里](./utils/download_pt_datasets.py)选择部分数据集进行下载. 
+> 您可以自由更改下载的数据集, 我们提供这个示例仅仅是为了复现目前的开源模型.
+
+### 预处理数据集
+
+我们需要使用 `tokenizer` 将数据集转为模型可接受的 `input_ids` 与 `attention_mask`.
+如果使用 `LlamaTokenizer` , 该 tokenizer 词表大小为 `32768` , 使用 `[INST]` 与 `[/INST]` 标记指令. 它还包括工具标记, 但是我们不会在这里使用它们.
+像 cosmopedia-v2 这样的数据集就包括 `prompt` 与 `text` 两个字段, 我们就将他们标记为用户内容与助手内容.
+
+```python
+conversation = [
+    {"role": "user", "content": prompt},
+    {"role": "assistant", "content": text},
+]
+return tokenizer.apply_chat_template(conversation, tokenize=True, padding='max_length', truncation=True, max_length=MAX_LENGTH, return_dict=True)
+```
+
+当然你也可以自行加入一些指令提示, 例如让模型能够回答我是Doge, 而不是 ChatGPT.
+
+```python
+conversation = [
+    {"role": "user", "content": "你是谁?"},
+    {"role": "assistant", "content": "我是一个名为 `Doge` 的 AI 助手, 我是由 `SmallDoge` 社区基于 `Doge` 架构训练的语言模型, 我的任务是根据用户的问题和请求提供适当的答案和支持."},
+    {"role": "user", "content": prompt},
+    {"role": "assistant", "content": text},
+]
+```
+
+在这里我们推荐使用 [Doge-tokenizer](https://huggingface.co/SmallDoge/Doge-tokenizer) 来处理数据集, 它是由 `Llama-3.3` 的分词器针对 `smollm-corpus` 训练得到的, 词表大小为 `32768` , 训练脚本可以在 [这里](https://github.com/SamllDoge/small-doge/blob/main/examples/utils/train_tokenizer_from_old.py) 找到.
+
+```shell
+# 填写数据集路径, 保存路径, 分词器路径, 样本数量, 最大长度和进程数
+python ./examples/utils/preprocess_pt_datasets.py --datasets_dir ./datasets --save_dir ./datasets --tokenizer_name_or_path SamllDoge/Doge-tokenizer --train_examples 128000000 --test_examples 1000 --max_length 2048 --num_proc 16
+```
+
+> [!NOTE]
+> 我们只保留 256B tokens 的数据集, 比例为 fineweb-edu:cosmopedia-v2:python-edu:open-web-math = 7:2:0.5:0.5, 如果你需要训练更大的模型, 请自行增加数据集的规模.
+
+### 合并数据集
+
+我们将 fineweb-edu_tokenized, cosmopedia-v2, python-edu 和 finemath 数据集合并为 `pretrain` 数据集.
+然后将它们打乱顺序 `seed=233` , 并拆分出来 `1,000` 个样本作为测试集.
+
+```shell
+# 填写数据集路径, 保存路径, 样本数量和进程数
+python ./examples/utils/concatenate_pt_datasets.py --datasets_dir ./datasets --save_dir ./datasets --train_examples 128000000 --test_examples 1000 --num_proc 16
+```
+
+### 配置模型参数
+
+我们配置一个 `20M` 的小型模型, 进行训练测试.
+
+| Model | Params | n_layers | d_model | d_ff | n_heads | kv_heads | n_exprets | n_expert_heads | n_expert_pre_head |
+|---|---|---|---|---|---|---|---|---|---|
+| Doge-20M | 13M | 8 | 256 | 512 | 2 | 1 | - | - | - |
+| Doge-60M | 54M | 16 | 512 | 1024 | 4 | 2 | - | - | - |
+| Doge-160M | 152M | 24 | 768 | 1536 | 6 | 3 | - | - | - |
+| Doge-320M | 335M | 32 | 1024 | 2048 | 8 | 4 | - | - | - |
+
+- n_layers 是模型的解码器层数
+- d_model 是模型的隐藏层维度
+- n_heads 是多头注意力头数 d_model // n_heads 最好保持在 64 以上
+
+> [!TIP]
+> `Doge-MoE` 模型可以继承 `Doge` 模型的密集激活参数, 并通过设置 `n_experts`, `n_expert_heads`, `n_expert_pre_head` 来增加稀疏激活的参数, 如果您希望增加模型参数而又不想增加计算成本, 可以尝试将模型配置的 `is_moe` 参数设置为 `True`, 并调整上述参数.
+
+### 配置预训练超参数
+
+| Model | tokens | max_train_steps | accumulate_steps | learning_rate | scheduler | warmup_ratio | decay_ratio | weight_decay | min_lr_rate |
+|---|---|---|---|---|---|---|---|---|---|
+| Doge-20M | 4B | 8,000 | 256 | 8e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+| Doge-60M | 16B | 16,000 | 512 | 6e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+| Doge-160M | 32B | 24,000 | 768 | 4e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+| Doge-320M | 64B | 32,000 | 1024 | 2e-3 | warmup_stable_decay | 0.1 | 0.1 | 0.01 | 0.0 |
+
+> [!NOTE]
+> 根据 [SmolLM博客](https://huggingface.co/blog/smollm) 的经验, 我们将 [Chinchilla](https://arxiv.org/pdf/2203.15556) 中参数与标记的缩放比例扩大 10 倍.
+> 使用 `warmup_stable_decay` 是为了随时使用检查点在更大的数据集上继续训练, 参见 [Scaling Laws and Compute-Optimal Training Beyond Fixed Training Durations](https://arxiv.org/pdf/2405.18392).
+
+### 预训练模型
+
+我们支持使用 Single GPU, DDP 或 DeepSpeed ZeRO-2 和 ZeRO-3 训练模型. 要在这四种方法之间切换, 只需更改 `recipes` 中 [`accelerate_configs`](../accelerate_configs) YAML 配置的路径.
+
+> [!NOTE]
+> 我们默认没有安装 `DeepSpeed`, 因为 Windows 系统不支持, 您如果需要使用, 请自行安装.
+
+```shell
+# 你需要指定配置文件路径, 所有参数都在配方配置文件中
+ACCELERATE_LOG_LEVEL=info accelerate launch ./src/small_doge/pt.py --config_file recipes/accelerate_configs/single_gpu.yaml --config recipes/doge/Doge-20M/config_full.yaml
+```
+
+> [!NOTE]
+> 上面的训练命令是为 1 x RTX 4090 (24GB) 节点配置的. 对于不同的硬件和拓扑, 您可能需要调整批量大小和梯度累积步数.
+
+### 使用
+
+在完成训练后, 我们可以使用 `Transformers` 的 `AutoModelForCausalLM` 加载模型, 并使用 `AutoTokenizer` 加载 `LlamaTokenizer` .
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-20M")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-20M", trust_remote_code=True)
+
+inputs = tokenizer("Hey how are you doing?", return_tensors="pt")
+
+out = model.generate(**inputs, max_new_tokens=20)
+print(tokenizer.batch_decode(out))
+```
+
+### 评估
+
+我们使用 [lighteval](https://github.com/huggingface/lighteval) 工具包来评估 Doge 模型的性能.
+
+你可以使用以下命令安装工具包:
+
+```bash
+pip install lighteval
+```
+
+> [!NOTE]
+> lighteval 默认会安装 `torch==2.4.1`, 也许你需要额外新建一个环境来安装.
+
+如果您是 Linux 用户, 您可以使用以下命令来评估模型:
+
+```bash
+bash ./evaluation/eval_downstream_tasks.sh
+```
+
+如果您是 Windows 用户, 您可以使用以下命令来评估模型:
+
+```bash
+. ./evaluation/eval_downstream_tasks.ps1
+```
+
+> [!NOTE]
+> 您可以在脚本中修改 `MODEL` 和 `OUTPUT_DIR` 来评估不同的模型并将结果保存到不同的目录中.
+
+
+## 指令微调
+
+我们提供了可以直接进行指令微调的基座Doge模型, 如果您有需要的话, 请参阅[这里](https://huggingface.co/collections/SmallDoge/doge-slm-679cc991f027c4a3abbded4a)以获取更多信息.
+
+### 下载数据集
+
+微调数据集, 我们选取了 `smoltalk` 数据集, 来进行监督微调, `ultrafeedback_binarized` 数据集, 来进行近端策略优化.
+
+```shell
+# 填写保存路径, 缓存路径和进程数
+python ./examples/utils/download_ft_dataset.py --save_dir ./datasets --cache_dir ./cache --num_proc 1
+```
+
+> [!NOTE]
+> 您可以自由更改下载的数据集, 我们提供这个示例仅仅是为了复现目前的开源模型.
+
+### 预处理数据集
+
+我们将微调数据集应用于`聊天模板`.
+
+```python
+# 填充数据集存放路径 数据集保存路径、分词器路径、进程数量 
+python ./examples/utils/preprocess_ft_datasets.py --datasets_dir ./datasets --save_dir ./datasets --tokenizer_name_or_path SmallDoge/Doge-tokenizer --num_proc 8
+```
+
+> [!NOTE]
+> 您可以在模板中添加一些指令提示, 例如让模型能够回答我是Doge, 而不是 ChatGPT.
+
+### 合并数据集
+
+如果你下载了更多数据集进行微调, 我们需要将其合并打乱来混合在一起.
+
+```shell
+# 填写数据集路径, 保存路径, 样本数量和进程数
+python ./examples/utils/concatenate_ft_datasets.py --datasets_dir ./datasets --save_dir ./datasets --num_proc 16
+```
+
+### 监督微调模型
+
+我们首先对模型进行监督微调, 使其更够跟随 `prompt` 来生成回复.
+
+```shell
+# 你需要指定配置文件路径, 所有参数都在配方配置文件中
+ACCELERATE_LOG_LEVEL=info accelerate launch ./src/small_doge/sft.py --config_file recipes/accelerate_configs/single_gpu.yaml --config recipes/doge/Doge-20M-Instruct/sft/config_full.yaml
+```
+
+> [!NOTE]
+> 上面的训练命令是为 1 x RTX 4090 (24GB) 节点配置的. 对于不同的硬件和拓扑, 您可能需要调整批量大小和梯度累积步数.
+
+### 近端策略优化模型
+
+然后我们对监督微调后的模型进行强化学习, 来与人类偏好对齐, 这里使用的是 `DPO` 算法.
+
+```shell
+# 你需要指定配置文件路径, 所有参数都在配方配置文件中
+ACCELERATE_LOG_LEVEL=info accelerate launch ./src/small_doge/dpo.py --config_file recipes/accelerate_configs/single_gpu.yaml --config recipes/doge/Doge-20M-Instruct/dpo/config_full.yaml
+```
+
+> [!NOTE]
+> 上面的训练命令是为 1 x RTX 4090 (24GB) 节点配置的. 对于不同的硬件和拓扑, 您可能需要调整批量大小和梯度累积步数.
+
+## 使用
+
+在完成微调后, 我们可以使用 `Transformers` 的 `AutoModelForCausalLM` 加载模型, 使用 `AutoTokenizer` 加载 `LlamaTokenizer`, 并使用 `GenerationConfig` 和 `
+TextStreamer` 来支持带有采样的流式生成.
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig, TextStreamer
+
+tokenizer = AutoTokenizer.from_pretrained("SmallDoge/Doge-20M-Instruct")
+model = AutoModelForCausalLM.from_pretrained("SmallDoge/Doge-20M-Instruct", trust_remote_code=True)
+
+generation_config = GenerationConfig(
+      max_new_tokens=100, 
+      use_cache=True, 
+      do_sample=True, 
+      temperature=0.8, 
+      top_p=0.9,
+      repetition_penalty=1.0
+)
+steamer = TextStreamer(tokenizer=tokenizer, skip_prompt=True)
+
+prompt = "Hi, how are you doing today?"
+
+conversation = [
+      {"role": "user", "content": prompt}
+]
+inputs = tokenizer.apply_chat_template(
+    conversation=conversation,
+    tokenize=True,
+    return_tensors="pt",
+)
+
+outputs = model.generate(
+    inputs, 
+    tokenizer=tokenizer,
+    generation_config=generation_config, 
+    streamer=steamer
+)
+```
+
+## 推理微调
+
+> [!NOTE]
+> 待办事项


### PR DESCRIPTION
This pull request includes updates to documentation and example notebooks related to the Doge model, focusing on pre-training and fine-tuning processes. The most important changes include updates to the pre-training and fine-tuning dataset instructions, and the addition of detailed training guides for both English and Chinese users.

Documentation Updates:

* [`recipes/doge/README.md`](diffhunk://#diff-b8ae0a998ebf8241064a9082bb8d80f025f0e40a404e8e24a77179a32b3ae43bR1-R267): Added detailed steps to train Doge, including pre-training, instruction fine-tuning, and reasoning fine-tuning. This guide covers installation, dataset download, preprocessing, model configuration, training, and evaluation.
* [`recipes/doge/README_zh.md`](diffhunk://#diff-fcaa387bf583fdc846b55049225d63a44128e399cdf2736150cfc0c59c06fc00R1-R268): Provided a translated version of the Doge training guide for Chinese users, including similar detailed steps as the English version.

Example Notebook Updates:

* [`examples/notebook.ipynb`](diffhunk://#diff-51046c546627619f6e496ae477ebd3dffebaa60f6185b63b7d506e210f94425fL27-R27): Updated the markdown cell to reflect changes in the pre-training dataset instructions, removing references to fine-tuning datasets.
* [`examples/notebook_zh.ipynb`](diffhunk://#diff-9388ee9c88a457a7f95d3c6b4ce2ccb94e6b7df33d9796a373bd65853fb3ac75L26-R26): Updated the Chinese version of the example notebook to reflect similar changes in the pre-training dataset instructions.